### PR TITLE
test: all possible move types for parsing target with move interpreter

### DIFF
--- a/spec/move/interpreter/move_interpreter_spec.rb
+++ b/spec/move/interpreter/move_interpreter_spec.rb
@@ -2,6 +2,7 @@ require './lib/move/interpreter/move_interpreter'
 require './lib/piece/chess_piece'
 require './lib/piece/piece_specs'
 require './lib/move/move'
+require 'move_samples'
 
 
 RSpec.configure do |cfg|
@@ -25,6 +26,18 @@ RSpec.describe MoveInterpreter do
         move = 'Nba3'
         target = interpreter.parse_target(move)
         expect(target).to eq({ file: 'a', rank: 3 })
+      end
+    end
+
+    context "when parsing all possible move types" do
+      it "returns the correct target square" do
+        expected = { file: 'a', rank: 3 }
+
+        result = MoveSamples::MOVES.all? do |move|
+          interpreter.parse_target(move) == expected
+        end
+
+        expect(result).to eq(true)
       end
     end
   end # describe '#parse_target'

--- a/spec/move_samples.rb
+++ b/spec/move_samples.rb
@@ -1,0 +1,8 @@
+module MoveSamples
+  MOVES = ["a3",
+           "a3+", "a3#", "Ra3",
+           "bxa3", "Ra3+", "Ra3#", "Nba3", "N1a3", "Rxa3",
+           "Nba3+", "Nba3#", "N1a3+", "N1a3#", "Rxa3+", "Rxa3#", "Rbxa3",
+           "R1xa3",
+           "Rbxa3+", "Rbxa3#", "R1xa3+", "R1xa3#"]
+end


### PR DESCRIPTION
- Castling moves excluded since the interpreter cannot parse them yet.